### PR TITLE
Tweak for compatibility with three.js >= r93

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function createBoundingBoxShape (object) {
     (box.max.z - box.min.z) / 2
   ));
 
-  localPosition = box.translate(clone.position.negate()).getCenter();
+  localPosition = box.translate(clone.position.negate()).getCenter(new THREE.Vector3());
   if (localPosition.lengthSq()) {
     shape.offset = localPosition;
   }


### PR DESCRIPTION
Just a tiny change -- [three.js decided to deprecate the version of this that doesn't accept a target](https://github.com/mrdoob/three.js/issues/12231).