### PR TITLE
(WIP) Avoid cloning object to create bounding box shape

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,16 +98,19 @@ module.exports = CANNON.mesh2shape = mesh2shape;
  * @return {CANNON.Shape}
  */
 function createBoundingBoxShape (object) {
-  var shape, localPosition,
-      box = new THREE.Box3();
+  var shape, box = new THREE.Box3(),
+      position = new THREE.Vector3(),
+      scale = new THREE.Vector3(),
+      offset = new THREE.Vector3(),
+      quaternion = object.quaternion.clone();
 
-  var clone = object.clone();
-  clone.quaternion.set(0, 0, 0, 1);
-  clone.updateMatrixWorld();
+  object.quaternion.set(0,0,0,1);
+  box.setFromObject(object);
 
-  box.setFromObject(clone);
-
-  if (!isFinite(box.min.lengthSq())) return null;
+  if (!isFinite(box.min.lengthSq())) {
+    object.quaternion.copy(quaternion);
+    return null;
+  }
 
   shape = new CANNON.Box(new CANNON.Vec3(
     (box.max.x - box.min.x) / 2,
@@ -115,11 +118,15 @@ function createBoundingBoxShape (object) {
     (box.max.z - box.min.z) / 2
   ));
 
-  localPosition = box.translate(clone.position.negate()).getCenter(new THREE.Vector3());
-  if (localPosition.lengthSq()) {
-    shape.offset = localPosition;
+  object.getWorldPosition(position);
+  object.getWorldScale(scale);
+  box.translate(position.negate()).getCenter(offset);
+
+  if (offset.lengthSq()) {
+    shape.offset = offset;
   }
 
+  object.quaternion.copy(quaternion);
   return shape;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,14 +79,63 @@ test('transform - position', function (t) {
   const box = mesh2shape(object);
 
   t.equal( box.type, ShapeType.BOX, 'box.type' );
-  t.equal( box.halfExtents.x, 5, 'box.halfExtents.x' );
-  t.equal( box.halfExtents.y, 5, 'box.halfExtents.y' );
-  t.equal( box.halfExtents.z, 5, 'box.halfExtents.z' );
-  t.equal( box.offset.x, 0, 'box.offset.x' );
-  t.equal( box.offset.y, 50, 'box.offset.y' );
-  t.equal( box.offset.z, 0, 'box.offset.z' );
+  t.ok( equalsApprox(box.halfExtents.x, 5), 'box.halfExtents.x' );
+  t.ok( equalsApprox(box.halfExtents.y, 5), 'box.halfExtents.y' );
+  t.ok( equalsApprox(box.halfExtents.z, 5), 'box.halfExtents.z' );
+  t.ok( equalsApprox(box.offset.x, 0), 'box.offset.x' );
+  t.ok( equalsApprox(box.offset.y, 50), 'box.offset.y' );
+  t.ok( equalsApprox(box.offset.z, 0), 'box.offset.z' );
   t.notOk( box.orientation, 'box.orientation' );
 
   t.end();
 });
 
+test('transform - position and scale', function (t) {
+  const parent = new THREE.Group();
+  const child = new THREE.Mesh(new THREE.BoxGeometry(10, 10, 10));
+  const translation = new THREE.Matrix4().makeTranslation(0, 50, 0);
+  child.geometry.applyMatrix(translation);
+  parent.position.set(100, 0, 0);
+  parent.scale.set(100, 100, 50);
+  parent.add(child);
+  parent.updateMatrixWorld();
+
+  const box = mesh2shape(child);
+
+  t.equal( box.type, ShapeType.BOX, 'box.type' );
+  t.ok( equalsApprox(box.halfExtents.x, 500), 'box.halfExtents.x' );
+  t.ok( equalsApprox(box.halfExtents.y, 500), 'box.halfExtents.y' );
+  t.ok( equalsApprox(box.halfExtents.z, 250), 'box.halfExtents.z' );
+  t.ok( equalsApprox(box.offset.x, 0), 'box.offset.x' );
+  t.ok( equalsApprox(box.offset.y, 5000), 'box.offset.y' );
+  t.ok( equalsApprox(box.offset.z, 0), 'box.offset.z' );
+
+  t.end();
+});
+
+test('transform - position and rotation', function (t) {
+  const group = new THREE.Group();
+  const object = new THREE.Mesh(new THREE.BoxGeometry(10, 10, 10));
+  const matrix = new THREE.Matrix4().makeTranslation(0, 50, 0);
+  const rotation = new THREE.Matrix4().makeRotationAxis(new THREE.Vector3(0,1,0), Math.PI/2);
+  const rotation2 = new THREE.Matrix4().makeRotationAxis(new THREE.Vector3(1,0,0), Math.PI/2);
+  group.applyMatrix(rotation);
+  object.applyMatrix(rotation2);
+  object.geometry.applyMatrix(matrix);
+  group.position.set(100, 0, 0);
+  group.add(object);
+  group.updateMatrixWorld();
+
+  const box = mesh2shape(object);
+
+  t.equal( box.type, ShapeType.BOX, 'box.type' );
+  t.ok( equalsApprox(box.halfExtents.x, 5), 'box.halfExtents.x' );
+  t.ok( equalsApprox(box.halfExtents.y, 5), 'box.halfExtents.y' );
+  t.ok( equalsApprox(box.halfExtents.z, 5), 'box.halfExtents.z' );
+  t.ok( equalsApprox(box.offset.x, 0), 'box.offset.x' );
+  t.ok( equalsApprox(box.offset.y, 50), 'box.offset.y' );
+  t.ok( equalsApprox(box.offset.z, 0), 'box.offset.z' );
+  t.notOk( box.orientation, 'box.orientation' );
+
+  t.end();
+});


### PR DESCRIPTION
**WIP: I realized there is an issue with this approach because I didn't call updateMatrixWorld. I need to fix this.**

Calling `object.clone()` on an object that requires constructor parameters can cause exceptions. For example, if you have an `Audio` node somewhere in your object hierarchy, `clone` will call its constructor but fail to pass in a `listener`: https://github.com/mrdoob/three.js/blob/db1a3392155fe67d54be82a25485ff10d4c49423/src/audio/Audio.js#L14 This results in a `ReferenceError`.

It's probably the case that `Audio` should be patched in `THREE` such that creating one with no `listener` doesn't have this error, and `copy()` is defined such that the `listener` is copied from one to the other, BUT we can get around that here by not cloning in the first place. I'm also not sure if that's the only type of `Object3D` that requires constructor params (which won't be provided when called by `clone()`).

I think the motivation for cloning the object was to reorient the clone to calculate the bounding box in line with its axes : https://github.com/donmccurdy/three-to-cannon/pull/8 However, given this issue we ran into with cloning, perhaps it's better to rotate the object at the beginning and end of the calculation rather than clone it. 
This change has the benefit of avoiding this error and the (expensive) call to clone, but has the downside of triggering any code someone may have attached to the object's quaternion change listener: https://github.com/mrdoob/three.js/blob/master/src/math/Quaternion.js#L172 Perhaps a patch to THREE really is necessary.

Another way to solve this problem is to replace `Box3.setFromObject` with an alternative method that calculates a box in the object's coordinate space. Then, we can transform the box by the object's worldMatrix to get its cannon shape info. This might be a preferred method for calculating bounding boxes in `aframe-physics-system`, because if you keep `halfExtents` in local space on a `shape` component, it is easy to adjust the `halfExtents` in cannon using the world scale of your object and the (local-space) `halfExtents` of the shape component. 

So, I'm not sure what's best. 

ALSO, I think there was an error where we weren't properly taking the object's world scale into account when computing `halfExtent`s. I added a test case for this which you can see fail if you don't include the changes to `createBoundingBoxShape`. We don't have to avoid cloning to fix that issue. I suspect the cloned object doesn't have the same worldScale of the object if the object's parent was scaled.