### PR TITLE
Use connected faces from generated convex hull

### DIFF
--- a/lib/ConvexHull.d.ts
+++ b/lib/ConvexHull.d.ts
@@ -13,4 +13,5 @@ declare class Face {
 declare class ConvexHull {
     public faces: Face[];
     setFromObject(mesh: Mesh): this;
+    collectFacesAndVertices(): { faces: number[][]; vertices: Vector3[]; }
 }

--- a/lib/ConvexHull.js
+++ b/lib/ConvexHull.js
@@ -1,5 +1,4 @@
 import {
-	BufferGeometry,
 	Line3,
 	Plane,
 	Triangle,
@@ -42,6 +41,41 @@ var ConvexHull = ( function () {
 
 	Object.assign( ConvexHull.prototype, {
 
+		collectFacesAndVertices: function () {
+			// Get face vertex indices.
+			// These indices reference the array positions of all input vertices, which include vertices inside the convex hull.
+			// These will be re-mapped to the convex hull's vertices, which exclude interior vertices.
+			const faceIndices = this.faces.map((f) => f.collectIndices());
+
+			// Get distinct vertex indices referenced by convex hull faces, in ascending order.
+			const referencedFaceIndices = Array.from(new Set(faceIndices.flat())).sort();
+
+			// Create a mapping between the original vertex indices to new vertex indices,
+			// excluding vertex indices that are not part of the generated convex hull.
+			const originalToNewIndex = new Map();
+			for (let i = 0; i < referencedFaceIndices.length; i++) {
+				originalToNewIndex.set(referencedFaceIndices[i], i);
+			}
+
+			// Get faces with remapped vertex indices.
+			const faces = [];
+			for (let i = 0; i < faceIndices.length; i++) {
+				const indices = faceIndices[i];
+				const a = originalToNewIndex.get(indices[0]);
+				const b = originalToNewIndex.get(indices[1]);
+				const c = originalToNewIndex.get(indices[2]);
+				faces.push([a, b, c]);
+			}
+
+			// Get vertices referenced by faces.
+			const vertices = [];
+			for (let i = 0; i < referencedFaceIndices.length; i++) {
+				vertices.push(this.vertices[referencedFaceIndices[i]].point);
+			}
+
+			return { faces, vertices };
+		},
+
 		setFromPoints: function ( points ) {
 
 			if ( Array.isArray( points ) !== true ) {
@@ -60,7 +94,7 @@ var ConvexHull = ( function () {
 
 			for ( var i = 0, l = points.length; i < l; i ++ ) {
 
-				this.vertices.push( new VertexNode( points[ i ] ) );
+				this.vertices.push( new VertexNode( points[ i ], i ) );
 
 			}
 
@@ -980,6 +1014,16 @@ var ConvexHull = ( function () {
 
 	Object.assign( Face.prototype, {
 
+		collectIndices: function () {
+			const indices = [];
+			let edge = this.edge;
+			do {
+				indices.push(edge.head().index);
+				edge = edge.next;
+			} while (edge !== this.edge);
+			return indices;
+		},
+
 		getEdge: function ( i ) {
 
 			var edge = this.edge;
@@ -1105,12 +1149,15 @@ var ConvexHull = ( function () {
 
 	// A vertex as a double linked list node.
 
-	function VertexNode( point ) {
+	function VertexNode( point, index ) {
 
 		this.point = point;
+		// index in the input array
+		this.index = index;
 		this.prev = null;
 		this.next = null;
-		this.face = null; // the face that is able to see this vertex
+		// the face that is able to see this vertex
+		this.face = null;
 
 	}
 


### PR DESCRIPTION
- Use connected faces from generated convex hull
  - Fixes #76 
  - Generated convex hulls did not have connected faces, which is required for convex-convex collision in cannon-es
  - Using the generated faces in ConvexHull addresses this
- Inspiration taken from discussion in cannon-es repo
  - https://github.com/pmndrs/cannon-es/issues/103
