### PR TITLE
fix types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "source": "./src/index.ts",
+  "types": "./dist/src/index.d.ts",
   "main": "./dist/three-to-cannon.cjs",
   "module": "./dist/three-to-cannon.esm.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "sideEffects": false,
   "source": "./src/index.ts",
-  "types": "./dist/src/index.d.ts",
   "main": "./dist/three-to-cannon.cjs",
   "module": "./dist/three-to-cannon.esm.js",
   "exports": {
+    "types": "./dist/src/index.d.ts",
     "require": "./dist/three-to-cannon.cjs",
     "default": "./dist/three-to-cannon.modern.js"
   },


### PR DESCRIPTION
The types field in package.json is no longer used if there is an [exports](https://nodejs.org/api/packages.html#exports) field:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

Therefore you should be good by simply copying your "types": "./dist/src/index.d.ts" indication within your exports.